### PR TITLE
Add: Compatibility for new town production in OpenTTD 14.0

### DIFF
--- a/src/cargos.nml
+++ b/src/cargos.nml
@@ -69,6 +69,8 @@ item (FEAT_CARGOS, cargo_waste, 2) {
         cargo_label:                "WSTE";
         town_growth_effect:         TOWNGROWTH_NONE;
         town_growth_multiplier:     0;
+        town_production_effect:     TOWNPRODUCTION_MAIL;
+        town_production_multiplier: 1.0;
         units_of_cargo:             TTD_STR_TONS;
         items_of_cargo:             string(STR_CARGO_QUANTITY_WASTE);
         penalty_lowerbound:         30;


### PR DESCRIPTION
https://github.com/OpenTTD/OpenTTD/pull/11947 changed the way town cargo generation is handled, which breaks the undefined behavior that allows Waste to be produced by houses ITI.

This PR fixes ITI to use the new defined behavior. It depends on https://github.com/OpenTTD/nml/pull/318.