### PR TITLE
Overjay's Hardware Store addition

### DIFF
--- a/make.py
+++ b/make.py
@@ -9,7 +9,7 @@ newgrf_name = "improved_town_industries"
 header_stuff = ["header", "cargos", "functions"]
 
 # Files to place in alphabetical order below
-unordered_stuff = ["coal_mine", "iron_mine", "steel_mill", "forest", "sawmill", "building_materials_factory", "factory", "food_processing_plant", "oil_wells", "oil_refinery", "paper_mill", "farm", "ranch", "recycling_center", "bank", "incinerator"]
+unordered_stuff = ["coal_mine", "iron_mine", "steel_mill", "forest", "sawmill", "building_materials_factory", "factory", "food_processing_plant", "oil_wells", "oil_refinery", "paper_mill", "farm", "ranch", "recycling_center", "bank", "incinerator", "hardware_store"]
 
 # Do you want to copy the completed NewGRF to your OpenTTD folder? (If in the typical location at "~/Documents/OpenTTD/newgrf")
 copy_bool = True

--- a/src/hardware_store.nml
+++ b/src/hardware_store.nml
@@ -1,0 +1,115 @@
+
+/* *** Begin Hardware Store *** */
+
+spritelayout sprlay_hardware_store_1 { // Main building
+	ground		{sprite:2149;}
+	building	{sprite:1475;}
+}
+
+spritelayout sprlay_hardware_store_2 { // Building materials tile
+	ground		{sprite:2149;}
+	building	{sprite:2149;}
+}
+
+item (FEAT_INDUSTRYTILES, ind_tile_hardware_store_1) { // Main building
+    property {
+        substitute:	08;
+        accepted_cargos: 	[[PASS, 8]];
+        special_flags:		bitmask(INDTILE_FLAG_ACCEPT_ALL);}
+    graphics {
+        default: sprlay_hardware_store_1;
+    }
+}
+
+item (FEAT_INDUSTRYTILES, ind_tile_hardware_store_2) { // Building materials tile
+    property {
+        substitute:	09;
+        accepted_cargos: 	[[PASS, 8]];
+        special_flags:		bitmask(INDTILE_FLAG_ACCEPT_ALL);}
+    graphics {
+        default: sprlay_hardware_store_2;
+    }
+}
+
+tilelayout industry_layout_hardware_store_1 { // 2 by 1 tile area
+    0,0:	ind_tile_hardware_store_1;
+    1,0:	ind_tile_hardware_store_2;    
+}
+
+tilelayout industry_layout_hardware_store_2 { // Mirrorred
+    0,0:	ind_tile_hardware_store_2;
+    1,0:	ind_tile_hardware_store_1;    
+}
+
+
+
+/* Location check */
+//IsCity() && IsNearTown() &&
+switch (FEAT_INDUSTRIES, SELF, loc_check_hardware_store, NoNearbyCompetitors(industry_hardware_store, 10) && IsWithinDistanceToTown(10)) {1: return CB_RESULT_LOCATION_ALLOW; return CB_RESULT_LOCATION_DISALLOW;}
+
+/* Hardware store industry */
+item (FEAT_INDUSTRIES, industry_hardware_store, 17) {
+	property {
+		substitute: INDUSTRYTYPE_POWER_PLANT;
+		life_type: IND_LIFE_TYPE_BLACK_HOLE;
+		spec_flags: 0;
+		cargo_types: [
+			accept_cargo("BDMT"),
+		];
+		name: string(STR_NAME_HARDWARE_STORE);
+		nearby_station_name: string(STR_STATION, string(STR_TOWN), string(STR_NAME_HARDWARE_STORE));
+        prob_map_gen: 1;
+        prob_in_game: 0;
+		fund_cost_multiplier: 100;
+		layouts: [			
+			industry_layout_hardware_store_1,
+			industry_layout_hardware_store_2,
+			];
+		map_colour: 39;
+	}
+	graphics {
+		extra_text_industry: string(STR_HARDWARE_STORE_HELPTEXT);
+        location_check: loc_check_hardware_store;
+	}
+}
+
+
+item (FEAT_OBJECTS, object_item_hardware_store_1) {
+	property {
+		class:					"HSIN";
+		classname:				string(STR_NAME_OBJECT_MENU);
+		name:					string(STR_NAME_HARDWARE_STORE);
+		climates_available:		ALL_CLIMATES;
+		object_flags:			bitmask(OBJ_FLAG_ANYTHING_REMOVE);
+		build_cost_multiplier:	0;
+		remove_cost_multiplier:	0;
+		size:					[1,1];
+		introduction_date:		1700;
+		num_views:				1;
+	}
+	graphics {
+		default:				sprlay_hardware_store_1;
+	}
+}
+
+item (FEAT_OBJECTS, object_item_hardware_store_2) {
+	property {
+		class:					"HSIN";
+		classname:				string(STR_NAME_OBJECT_MENU);
+		name:					string(STR_NAME_HARDWARE_STORE_MATS);
+		climates_available:		ALL_CLIMATES;
+		object_flags:			bitmask(OBJ_FLAG_ANYTHING_REMOVE);
+		build_cost_multiplier:	0;
+		remove_cost_multiplier:	0;
+		size:					[1,1];
+		introduction_date:		1700;
+		num_views:				1;
+	}
+	graphics {
+		default:				sprlay_hardware_store_2;
+	}
+}
+
+
+
+/* *** End Incinerator *** */

--- a/src/hardware_store.nml
+++ b/src/hardware_store.nml
@@ -44,8 +44,9 @@ tilelayout industry_layout_hardware_store_2 { // Mirrorred
 
 
 /* Location check */
-//IsCity() && IsNearTown() &&
+
 switch (FEAT_INDUSTRIES, SELF, loc_check_hardware_store, NoNearbyCompetitors(industry_hardware_store, 10) && IsWithinDistanceToTown(10)) {1: return CB_RESULT_LOCATION_ALLOW; return CB_RESULT_LOCATION_DISALLOW;}
+
 
 /* Hardware store industry */
 item (FEAT_INDUSTRIES, industry_hardware_store, 17) {
@@ -58,7 +59,7 @@ item (FEAT_INDUSTRIES, industry_hardware_store, 17) {
 		];
 		name: string(STR_NAME_HARDWARE_STORE);
 		nearby_station_name: string(STR_STATION, string(STR_TOWN), string(STR_NAME_HARDWARE_STORE));
-        prob_map_gen: 1;
+        prob_map_gen: param_hardware_store;
         prob_in_game: 0;
 		fund_cost_multiplier: 100;
 		layouts: [			

--- a/src/hardware_store.nml
+++ b/src/hardware_store.nml
@@ -2,13 +2,19 @@
 /* *** Begin Hardware Store *** */
 
 spritelayout sprlay_hardware_store_1 { // Main building
-	ground		{sprite:2149;}
-	building	{sprite:1475;}
+	ground		{sprite:1420;}
+	building	{sprite:2190;
+				recolour_mode: RECOLOUR_REMAP;
+				palette: PALETTE_USE_DEFAULT;}
 }
 
 spritelayout sprlay_hardware_store_2 { // Building materials tile
-	ground		{sprite:2149;}
-	building	{sprite:2149;}
+	ground		{sprite:1420;}
+	building	{sprite:2199;}
+}
+
+spritelayout sprlay_hardware_store_3 { // Concrete tile
+	ground		{sprite:1420;}	
 }
 
 item (FEAT_INDUSTRYTILES, ind_tile_hardware_store_1) { // Main building
@@ -31,17 +37,15 @@ item (FEAT_INDUSTRYTILES, ind_tile_hardware_store_2) { // Building materials til
     }
 }
 
-tilelayout industry_layout_hardware_store_1 { // 2 by 1 tile area
+tilelayout industry_layout_hardware_store_1 { // 2x1 Tile area
     0,0:	ind_tile_hardware_store_1;
     1,0:	ind_tile_hardware_store_2;    
 }
 
-tilelayout industry_layout_hardware_store_2 { // Mirrorred
+tilelayout industry_layout_hardware_store_2 { // 2x1 Mirrorred
     0,0:	ind_tile_hardware_store_2;
     1,0:	ind_tile_hardware_store_1;    
 }
-
-
 
 /* Location check */
 
@@ -71,6 +75,7 @@ item (FEAT_INDUSTRIES, industry_hardware_store, 17) {
 	graphics {
 		extra_text_industry: string(STR_HARDWARE_STORE_HELPTEXT);
         location_check: loc_check_hardware_store;
+		colour: COLOUR_PALE_GREEN;
 	}
 }
 
@@ -90,27 +95,12 @@ item (FEAT_OBJECTS, object_item_hardware_store_1) {
 	}
 	graphics {
 		default:				sprlay_hardware_store_1;
-	}
-}
-
-item (FEAT_OBJECTS, object_item_hardware_store_2) {
-	property {
-		class:					"HSIN";
-		classname:				string(STR_NAME_OBJECT_MENU);
-		name:					string(STR_NAME_HARDWARE_STORE_MATS);
-		climates_available:		ALL_CLIMATES;
-		object_flags:			bitmask(OBJ_FLAG_ANYTHING_REMOVE);
-		build_cost_multiplier:	0;
-		remove_cost_multiplier:	0;
-		size:					[1,1];
-		introduction_date:		1700;
-		num_views:				1;
-	}
-	graphics {
-		default:				sprlay_hardware_store_2;
+		colour: COLOUR_PALE_GREEN;
 	}
 }
 
 
 
-/* *** End Incinerator *** */
+
+
+/* *** End Hardware Store *** */

--- a/src/header.nml
+++ b/src/header.nml
@@ -14,6 +14,16 @@ grf {
 			def_value: 1;
 		}
 	}
+	
+	param 1 {
+		param_hardware_store{
+		type:bool;
+		name: string(STR_PARAM_HARDWARE_STORE_NAME);
+		desc: string(STR_PARAM_HARDWARE_STORE_DESC);
+		def_value: 1;
+		}	
+	
+	}
 }
 
 /* Disable base game industries */

--- a/src/lang/english.lng
+++ b/src/lang/english.lng
@@ -24,6 +24,8 @@ STR_PRIMARY_HELPTEXT                :{SKIP}{SKIP}{STRING}{}{}Production efficien
 STR_SECONDARY_HELPTEXT              :{SKIP}{SKIP}Consumes 1 unit of each input cargo per 5 population. Current maximum {YELLOW}{UNSIGNED_WORD}{BLACK}/month.{}{}Production efficiency: {SKIP}{YELLOW}{UNSIGNED_WORD}% {SKIP}{BLACK}{}{}{STRING}
 
 STR_INCINERATOR_HELPTEXT            :Consumes Waste but has no other effect.
+STR_NAME_HARDWARE_STORE_MATS		:Bulding materials tile
+STR_HARDWARE_STORE_HELPTEXT			:Consumes Building Materials but has no other effect.
 
 STR_LOC_ERROR_PRIMARY               :Primary industries cannot be funded near cities and must be at a suitable elevation.
 STR_LOC_ERROR_SECONDARY             :Secondary industries must be near a city with no other secondary industries.
@@ -52,6 +54,7 @@ STR_NAME_FOOD_PROCESSING_PLANT      :Food Processing Plant
 STR_NAME_RANCH                      :Ranch
 STR_NAME_BANK                       :Bank
 STR_NAME_INCINERATOR                :Incinerator
+STR_NAME_HARDWARE_STORE             :Hardware Store
 
 STR_NAME_FIELD_1					:Field
 

--- a/src/lang/english.lng
+++ b/src/lang/english.lng
@@ -11,6 +11,9 @@ STR_ERROR_INCOMPATIBLE_SET          :{YELLOW}{TITLE}{WHITE} is incompatible with
 
 STR_PARAM_PRIMARY_QUADRANTS_NAME    :Primary industry regions
 STR_PARAM_PRIMARY_QUADRANTS_DESC    :{LTBLUE}Default value: {ORANGE}On{}{WHITE}If enabled, primary industries spawn only in certain parts of the map.
+STR_PARAM_HARDWARE_STORE_NAME		:Allow hardware store to spawn
+STR_PARAM_HARDWARE_STORE_DESC		:This option regulates if hardware store - a consumer of building materials cargo - is allowed to spawn. Toggle to off if you're using Improved Town Layouts NewGRF, since it adds its own consumer of that cargo type. Default - allowed
+
 
 STR_PRIMARY_GOAL_1000               :{BLACK}To {WHITE}increase maximum production {BLACK}, grow town to 1,000 population.
 STR_PRIMARY_GOAL_2000               :{BLACK}To {WHITE}increase maximum production {BLACK}, grow town to 2,000 population.


### PR DESCRIPTION
Added Hardware Store as a small blackhole kind of secondary industry to have an ending to the Building Materials cargo loop, which is open unless Improved Town Houses is installed.

I've playtested it, RVG tracks the delivery of Building Materials successfully. Price for funding this industry is made intentionally low-ish, since this industry is required for a good town growth, and it did not sit right with me to require same price for the factory kind of installation AND for a comparatively small shed with some construction materials.

EDIT:
I've also added a button to the settings of the mod, so if a player uses Improved Town Layouts - they can opt out of Hardware Store spawning in-world automatically. 
