### PR TITLE
Remade graphics for Forest industry to be snow-aware

### DIFF
--- a/src/forest.nml
+++ b/src/forest.nml
@@ -1,332 +1,332 @@
 
 /* *** Begin Forest *** */
 
-spritelayout sprlay_forest_temp_pine1_growing{
+spritelayout sprlay_forest_temp_pine1_growing {
 	ground	{sprite:3962;}
 	//top corner
 	building	{
-	sprite: (construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
-	xoffset: 0;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		xoffset: 0;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//bottom corner
 	building {
-	sprite:(construction_state==0 ? 1653 : construction_state==1 ? 1654 : construction_state==2 ? 1655 : 1656);
-	xoffset: 8;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1653 : construction_state == 1 ? 1654 : construction_state == 2 ? 1655 : 1656);
+		xoffset: 8;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 	// left corner
 	building {
-	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
-	xoffset: 8;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		xoffset: 8;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//right corner
 	building {
-	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
-	xoffset: 0;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		xoffset: 0;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 }
 
-spritelayout sprlay_forest_temp_pine2_growing{
+spritelayout sprlay_forest_temp_pine2_growing {
 	ground	{sprite:3962;}
 	//top corner
 	building	{
-	sprite: (construction_state==0 ? 1611 : construction_state==1 ? 1612 : construction_state==2 ? 1613 : 1614);
-	xoffset: 0;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (construction_state == 0 ? 1611 : construction_state == 1 ? 1612 : construction_state == 2 ? 1613 : 1614);
+		xoffset: 0;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//bottom corner
 	building {
-	sprite: (construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
-	xoffset: 8;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite: (construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		xoffset: 8;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 	// left corner
 	building {
-	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
-	xoffset: 8;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		xoffset: 8;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//right corner
 	building {
-	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
-	xoffset: 0;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		xoffset: 0;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 }
 
-spritelayout sprlay_forest_temp_brdlfs_growing{
+spritelayout sprlay_forest_temp_brdlfs_growing {
 	ground		{sprite: 3962;} 
 	// top corner
 	building	{
-	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
-	xoffset: 0;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1590 : construction_state == 1 ? 1591 : construction_state == 2 ? 1592 : 1593);
+		xoffset: 0;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//bottom corner
 	building {
-	sprite:(construction_state==0 ? 1611 : construction_state==1 ? 1612 : construction_state==2 ? 1613 : 1614);
-	xoffset: 8;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1611 : construction_state == 1 ? 1612 : construction_state == 2 ? 1613 : 1614);
+		xoffset: 8;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 	// left corner
 	building {
-	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
-	xoffset: 8;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1590 : construction_state == 1 ? 1591 : construction_state == 2 ? 1592 : 1593);
+		xoffset: 8;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//right corner
 	building {
-	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
-	xoffset: 0;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1590 : construction_state == 1 ? 1591 : construction_state == 2 ? 1592 : 1593);
+		xoffset: 0;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
-
 }
 
-spritelayout sprlay_forest_temp_mixed_growing{
+spritelayout sprlay_forest_temp_mixed_growing {
 	ground		{sprite: 3962;}
 	// top corner
 	building	{
-	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
-	xoffset: 0;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1590 : construction_state == 1 ? 1591 : construction_state == 2 ? 1592 : 1593);
+		xoffset: 0;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//bottom corner
 	building {
-	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
-	xoffset: 8;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1590 : construction_state == 1 ? 1591 : construction_state == 2 ? 1592 : 1593);
+		xoffset: 8;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 	// left corner
 	building {
-	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
-	xoffset: 8;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		xoffset: 8;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//right corner
 	building {
-	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
-	xoffset: 0;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		xoffset: 0;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 }
 
-spritelayout sprlay_forest_brownground{
+spritelayout sprlay_forest_brownground {
 		ground		{sprite: 2022;} 
 	}
 	
-spritelayout sprlay_forest_logginghouse{
+spritelayout sprlay_forest_logginghouse {
 		ground		{sprite: 2022;} 
 		building	{sprite: 2063;}
 	}	
 
-spritelayout sprlay_forest_snowy_pine1_growing{
+spritelayout sprlay_forest_snowy_pine1_growing {
 	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
 	//top corner 1765
 	building	{
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
-	xoffset: 0;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1765 : construction_state == 1 ? 1766 : construction_state == 2 ? 1767 : 1768) : (construction_state == 0 ? 1709 : construction_state == 1 ? 1710 : construction_state == 2 ? 1711 : 1712));
+		xoffset: 0;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//bottom corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1800 : construction_state==1 ? 1801 : construction_state==2 ? 1802 : 1803) : (construction_state==0 ? 1744 : construction_state==1 ? 1745 : construction_state==2 ? 1746 : 1747));
-	xoffset: 8;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1800 : construction_state == 1 ? 1801 : construction_state == 2 ? 1802 : 1803) : (construction_state == 0 ? 1744 : construction_state == 1 ? 1745 : construction_state == 2 ? 1746 : 1747));
+		xoffset: 8;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 	// left corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
-	xoffset: 8;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1765 : construction_state == 1 ? 1766 : construction_state == 2 ? 1767 : 1768) : (construction_state == 0 ? 1709 : construction_state == 1 ? 1710 : construction_state == 2 ? 1711 : 1712));
+		xoffset: 8;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//right corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
-	xoffset: 0;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1765 : construction_state == 1 ? 1766 : construction_state == 2 ? 1767 : 1768) : (construction_state == 0 ? 1709 : construction_state == 1 ? 1710 : construction_state == 2 ? 1711 : 1712));
+		xoffset: 0;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 }
 
-spritelayout sprlay_forest_snowy_pine2_growing{
+spritelayout sprlay_forest_snowy_pine2_growing {
 	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
 	//top corner 
 	building	{
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1786 : construction_state==1 ? 1787 : construction_state==2 ? 1788 : 1789) : (construction_state==0 ? 1730 : construction_state==1 ? 1731 : construction_state==2 ? 1732 : 1733));
-	xoffset: 0;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type  ==  TILETYPE_SNOW ? (construction_state == 0 ? 1786 : construction_state == 1 ? 1787 : construction_state == 2 ? 1788 : 1789) : (construction_state == 0 ? 1730 : construction_state == 1 ? 1731 : construction_state == 2 ? 1732 : 1733));
+		xoffset: 0;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//bottom corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
-	xoffset: 8;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1765 : construction_state == 1 ? 1766 : construction_state == 2 ? 1767 : 1768) : (construction_state == 0 ? 1709 : construction_state == 1 ? 1710 : construction_state == 2 ? 1711 : 1712));
+		xoffset: 8;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 	// left corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
-	xoffset: 8;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1765 : construction_state == 1 ? 1766 : construction_state == 2 ? 1767 : 1768) : (construction_state == 0 ? 1709 : construction_state == 1 ? 1710 : construction_state == 2 ? 1711 : 1712));
+		xoffset: 8;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//right corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
-	xoffset: 0;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1765 : construction_state == 1 ? 1766 : construction_state == 2 ? 1767 : 1768) : (construction_state == 0 ? 1709 : construction_state == 1 ? 1710 : construction_state == 2 ? 1711 : 1712));
+		xoffset: 0;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 }
 
-spritelayout sprlay_forest_snowy_brdlfs_growing{
+spritelayout sprlay_forest_snowy_brdlfs_growing {
 	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
 	//top corner 
 	building	{
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
-	xoffset: 0;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1772 : construction_state == 1 ? 1773 : construction_state == 2 ? 1774 : 1775) : (construction_state == 0 ? 1716 : construction_state == 1 ? 1717 : construction_state == 2 ? 1718 : 1719));
+		xoffset: 0;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//bottom corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1786 : construction_state==1 ? 1787 : construction_state==2 ? 1788 : 1789) : (construction_state==0 ? 1730 : construction_state==1 ? 1731 : construction_state==2 ? 1732 : 1733));
-	xoffset: 8;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1786 : construction_state == 1 ? 1787 : construction_state == 2 ? 1788 : 1789) : (construction_state == 0 ? 1730 : construction_state == 1 ? 1731 : construction_state == 2 ? 1732 : 1733));
+		xoffset: 8;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 	// left corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
-	xoffset: 8;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1772 : construction_state == 1 ? 1773 : construction_state == 2 ? 1774 : 1775) : (construction_state == 0 ? 1716 : construction_state == 1 ? 1717 : construction_state == 2 ? 1718 : 1719));
+		xoffset: 8;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//right corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
-	xoffset: 0;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1772 : construction_state == 1 ? 1773 : construction_state == 2 ? 1774 : 1775) : (construction_state == 0 ? 1716 : construction_state == 1 ? 1717 : construction_state == 2 ? 1718 : 1719));
+		xoffset: 0;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 }
 
-spritelayout sprlay_forest_snowy_mixed_growing{
+spritelayout sprlay_forest_snowy_mixed_growing {
 	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
 	//top corner 
 	building	{
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
-	xoffset: 0;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type  ==  TILETYPE_SNOW ? (construction_state == 0 ? 1772 : construction_state == 1 ? 1773 : construction_state == 2 ? 1774 : 1775) : (construction_state == 0 ? 1716 : construction_state == 1 ? 1717 : construction_state == 2 ? 1718 : 1719));
+		xoffset: 0;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//bottom corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
-	xoffset: 8;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1772 : construction_state == 1 ? 1773 : construction_state == 2 ? 1774 : 1775) : (construction_state == 0 ? 1716 : construction_state == 1 ? 1717 : construction_state == 2 ? 1718 : 1719));
+		xoffset: 8;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 	// left corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
-	xoffset: 8;
-	yoffset: 0;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1765 : construction_state == 1 ? 1766 : construction_state == 2 ? 1767 : 1768) : (construction_state == 0 ? 1709 : construction_state == 1 ? 1710 : construction_state == 2 ? 1711 : 1712));
+		xoffset: 8;
+		yoffset: 0;
+		xextent: 8;
+		yextent: 8;
 	}
 	//right corner
 	building {
-	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
-	xoffset: 0;
-	yoffset: 8;
-	xextent: 8;
-	yextent: 8;
+		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1765 : construction_state == 1 ? 1766 : construction_state == 2 ? 1767 : 1768) : (construction_state == 0 ? 1709 : construction_state == 1 ? 1710 : construction_state == 2 ? 1711 : 1712));
+		xoffset: 0;
+		yoffset: 8;
+		xextent: 8;
+		yextent: 8;
 	}
 }
 
 /* TEMPERATE and ARCTIC graphics switches */
 
-switch (FEAT_INDUSTRYTILES, SELF, switch_forest_pine1_selector, climate == CLIMATE_ARCTIC){
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_pine1_selector, climate == CLIMATE_ARCTIC) {
 	1: return sprlay_forest_snowy_pine1_growing;
 	0: return sprlay_forest_temp_pine1_growing;
-	}
+}
 	
-switch (FEAT_INDUSTRYTILES, SELF, switch_forest_pine2_selector, climate == CLIMATE_ARCTIC){
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_pine2_selector, climate == CLIMATE_ARCTIC) {
 	1: return sprlay_forest_snowy_pine2_growing;
 	0: return sprlay_forest_temp_pine2_growing;
-	}
-switch (FEAT_INDUSTRYTILES, SELF, switch_forest_brdlfs_selector, climate == CLIMATE_ARCTIC){
+}
+
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_brdlfs_selector, climate == CLIMATE_ARCTIC) {
 	1: return sprlay_forest_snowy_brdlfs_growing;
 	0: return sprlay_forest_temp_brdlfs_growing;
-	}
+}
 	
-switch (FEAT_INDUSTRYTILES, SELF, switch_forest_mixed_selector, climate == CLIMATE_ARCTIC){
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_mixed_selector, climate == CLIMATE_ARCTIC) {
 	1: return sprlay_forest_snowy_mixed_growing;
 	0: return sprlay_forest_temp_mixed_growing;
-	}	
+}	
 
 item (FEAT_INDUSTRYTILES, ind_tile_forest_mixed) {
     property {
         substitute: 16;
-        //override: 16;
+        override: 16;
         accepted_cargos: [[PASS, 8]];
     }
-	graphics{
+	graphics {
 		default: switch_forest_mixed_selector;
 	}
 }
@@ -334,10 +334,10 @@ item (FEAT_INDUSTRYTILES, ind_tile_forest_mixed) {
 item (FEAT_INDUSTRYTILES, ind_tile_forest_pine1) {
     property {
         substitute: 16;
-        //override: 16;
+        override: 16;
         accepted_cargos: [[PASS, 8]];
     }
-	graphics{
+	graphics {
 		default: switch_forest_pine1_selector;
 	}
 }
@@ -345,10 +345,10 @@ item (FEAT_INDUSTRYTILES, ind_tile_forest_pine1) {
 item (FEAT_INDUSTRYTILES, ind_tile_forest_pine2) {
     property {
         substitute: 16;
-        //override: 16;
+        override: 16;
         accepted_cargos: [[PASS, 8]];
     }
-	graphics{
+	graphics {
 		default: switch_forest_pine2_selector;
 	}
 }
@@ -356,10 +356,10 @@ item (FEAT_INDUSTRYTILES, ind_tile_forest_pine2) {
 item (FEAT_INDUSTRYTILES, ind_tile_forest_brdlfs) {
     property {
         substitute: 16;
-        //override: 16;
+        override: 16;
         accepted_cargos: [[PASS, 8]];
     }
-	graphics{
+	graphics {
 		default: switch_forest_brdlfs_selector;
 	}
 }
@@ -367,10 +367,10 @@ item (FEAT_INDUSTRYTILES, ind_tile_forest_brdlfs) {
 item (FEAT_INDUSTRYTILES, ind_tile_forest_brownground) {
     property {
         substitute: 16;
-        //override: 16;
+        override: 16;
         accepted_cargos: [[PASS, 8]];
     }
-	graphics{
+	graphics {
 		default: sprlay_forest_brownground;
 	}
 }
@@ -378,10 +378,10 @@ item (FEAT_INDUSTRYTILES, ind_tile_forest_brownground) {
 item (FEAT_INDUSTRYTILES, ind_tile_forest_logginghouse) {
     property {
         substitute: 16;
-        //override: 16;
+        override: 16;
         accepted_cargos: [[PASS, 8]];
     }
-	graphics{
+	graphics {
 		default: sprlay_forest_logginghouse;
 	}
 }
@@ -469,13 +469,12 @@ item (FEAT_INDUSTRIES, industry_forest, 3) {
 		nearby_station_name: string(STR_STATION, string(STR_TOWN), string(STR_NAME_FOREST));
         prob_map_gen: 2; // Account for difficulty of finding suitable locatiom
         prob_in_game: 0;
-		fund_cost_multiplier: 255;
-		
+		fund_cost_multiplier: 255;		
 	}
 	graphics {
 		extra_text_industry: StringGetPrimaryHelptext();
         location_check: loc_check_forest;
-        produce_256_ticks: switch_produce_forest;			
+        produce_256_ticks: switch_produce_forest;
         /* Don't allow any production changes */
 		build_prod_change: 16; // 100% production
 		monthly_prod_change: CB_RESULT_IND_PROD_NO_CHANGE;

--- a/src/forest.nml
+++ b/src/forest.nml
@@ -2,7 +2,7 @@
 /* *** Begin Forest *** */
 
 spritelayout sprlay_forest_temp_pine1_growing{
-	ground	{sprite:3943;}
+	ground	{sprite:3962;}
 	//top corner
 	building	{
 	sprite: (construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
@@ -38,7 +38,7 @@ spritelayout sprlay_forest_temp_pine1_growing{
 }
 
 spritelayout sprlay_forest_temp_pine2_growing{
-	ground	{sprite:3943;}
+	ground	{sprite:3962;}
 	//top corner
 	building	{
 	sprite: (construction_state==0 ? 1611 : construction_state==1 ? 1612 : construction_state==2 ? 1613 : 1614);
@@ -74,7 +74,7 @@ spritelayout sprlay_forest_temp_pine2_growing{
 }
 
 spritelayout sprlay_forest_temp_brdlfs_growing{
-	ground		{sprite: 3943;} 
+	ground		{sprite: 3962;} 
 	// top corner
 	building	{
 	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
@@ -111,7 +111,7 @@ spritelayout sprlay_forest_temp_brdlfs_growing{
 }
 
 spritelayout sprlay_forest_temp_mixed_growing{
-	ground		{sprite: 3943;}
+	ground		{sprite: 3962;}
 	// top corner
 	building	{
 	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);

--- a/src/forest.nml
+++ b/src/forest.nml
@@ -1,11 +1,13 @@
 
 /* *** Begin Forest *** */
 
-spritelayout sprlay_forest_temp_pine1_growing {
+/* TEMPERATE tiles */
+
+spritelayout sprlay_forest_temp_tile1 {
 	ground	{sprite:3962;}
 	//top corner
 	building	{
-		sprite: (construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		sprite: (construction_state == 0 ? 1688 : construction_state == 1 ? 1689 : construction_state == 2 ? 1690 : 1691);
 		xoffset: 0;
 		yoffset: 0;
 		xextent: 8;
@@ -21,7 +23,7 @@ spritelayout sprlay_forest_temp_pine1_growing {
 	}
 	// left corner
 	building {
-		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		sprite: (construction_state == 0 ? 1688 : construction_state == 1 ? 1689 : construction_state == 2 ? 1690 : 1691);
 		xoffset: 8;
 		yoffset: 0;
 		xextent: 8;
@@ -29,7 +31,7 @@ spritelayout sprlay_forest_temp_pine1_growing {
 	}
 	//right corner
 	building {
-		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		sprite: (construction_state == 0 ? 1688 : construction_state == 1 ? 1689 : construction_state == 2 ? 1690 : 1691);
 		xoffset: 0;
 		yoffset: 8;
 		xextent: 8;
@@ -37,7 +39,7 @@ spritelayout sprlay_forest_temp_pine1_growing {
 	}
 }
 
-spritelayout sprlay_forest_temp_pine2_growing {
+spritelayout sprlay_forest_temp_tile2 {
 	ground	{sprite:3962;}
 	//top corner
 	building	{
@@ -49,7 +51,7 @@ spritelayout sprlay_forest_temp_pine2_growing {
 	}
 	//bottom corner
 	building {
-		sprite: (construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		sprite: (construction_state == 0 ? 1688 : construction_state == 1 ? 1689 : construction_state == 2 ? 1690 : 1691);
 		xoffset: 8;
 		yoffset: 8;
 		xextent: 8;
@@ -57,7 +59,7 @@ spritelayout sprlay_forest_temp_pine2_growing {
 	}
 	// left corner
 	building {
-		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		sprite: (construction_state == 0 ? 1688 : construction_state == 1 ? 1689 : construction_state == 2 ? 1690 : 1691);
 		xoffset: 8;
 		yoffset: 0;
 		xextent: 8;
@@ -65,7 +67,7 @@ spritelayout sprlay_forest_temp_pine2_growing {
 	}
 	//right corner
 	building {
-		sprite:(construction_state == 0 ? 1660 : construction_state == 1 ? 1661 : construction_state == 2 ? 1662 : 1663);
+		sprite: (construction_state == 0 ? 1688 : construction_state == 1 ? 1689 : construction_state == 2 ? 1690 : 1691);
 		xoffset: 0;
 		yoffset: 8;
 		xextent: 8;
@@ -73,7 +75,7 @@ spritelayout sprlay_forest_temp_pine2_growing {
 	}
 }
 
-spritelayout sprlay_forest_temp_brdlfs_growing {
+spritelayout sprlay_forest_temp_tile3 {
 	ground		{sprite: 3962;} 
 	// top corner
 	building	{
@@ -109,7 +111,7 @@ spritelayout sprlay_forest_temp_brdlfs_growing {
 	}
 }
 
-spritelayout sprlay_forest_temp_mixed_growing {
+spritelayout sprlay_forest_temp_tile4 {
 	ground		{sprite: 3962;}
 	// top corner
 	building	{
@@ -145,18 +147,11 @@ spritelayout sprlay_forest_temp_mixed_growing {
 	}
 }
 
-spritelayout sprlay_forest_brownground {
-		ground		{sprite: 2022;} 
-	}
-	
-spritelayout sprlay_forest_logginghouse {
-		ground		{sprite: 2022;} 
-		building	{sprite: 2063;}
-	}	
+/* ARCTIC tiles */
 
-spritelayout sprlay_forest_snowy_pine1_growing {
+spritelayout sprlay_forest_snowy_tile1 {
 	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
-	//top corner 1765
+	//top corner
 	building	{
 		sprite: (terrain_type == TILETYPE_SNOW ? (construction_state == 0 ? 1765 : construction_state == 1 ? 1766 : construction_state == 2 ? 1767 : 1768) : (construction_state == 0 ? 1709 : construction_state == 1 ? 1710 : construction_state == 2 ? 1711 : 1712));
 		xoffset: 0;
@@ -190,7 +185,7 @@ spritelayout sprlay_forest_snowy_pine1_growing {
 	}
 }
 
-spritelayout sprlay_forest_snowy_pine2_growing {
+spritelayout sprlay_forest_snowy_tile2 {
 	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
 	//top corner 
 	building	{
@@ -226,7 +221,7 @@ spritelayout sprlay_forest_snowy_pine2_growing {
 	}
 }
 
-spritelayout sprlay_forest_snowy_brdlfs_growing {
+spritelayout sprlay_forest_snowy_tile3 {
 	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
 	//top corner 
 	building	{
@@ -262,7 +257,7 @@ spritelayout sprlay_forest_snowy_brdlfs_growing {
 	}
 }
 
-spritelayout sprlay_forest_snowy_mixed_growing {
+spritelayout sprlay_forest_snowy_tile4 {
 	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
 	//top corner 
 	building	{
@@ -298,69 +293,80 @@ spritelayout sprlay_forest_snowy_mixed_growing {
 	}
 }
 
+/* Logging house and brown ground tiles */
+
+spritelayout sprlay_forest_brownground {
+		ground		{sprite: 2022;} 
+	}
+	
+spritelayout sprlay_forest_logginghouse {
+		ground		{sprite: 2022;} 
+		building	{sprite: 2063;}
+	}	
+
 /* TEMPERATE and ARCTIC graphics switches */
 
-switch (FEAT_INDUSTRYTILES, SELF, switch_forest_pine1_selector, climate == CLIMATE_ARCTIC) {
-	1: return sprlay_forest_snowy_pine1_growing;
-	0: return sprlay_forest_temp_pine1_growing;
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_tile1_selector, climate == CLIMATE_ARCTIC) {
+	1: return sprlay_forest_snowy_tile1;
+	0: return sprlay_forest_temp_tile1;
 }
 	
-switch (FEAT_INDUSTRYTILES, SELF, switch_forest_pine2_selector, climate == CLIMATE_ARCTIC) {
-	1: return sprlay_forest_snowy_pine2_growing;
-	0: return sprlay_forest_temp_pine2_growing;
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_tile2_selector, climate == CLIMATE_ARCTIC) {
+	1: return sprlay_forest_snowy_tile2;
+	0: return sprlay_forest_temp_tile2;
 }
 
-switch (FEAT_INDUSTRYTILES, SELF, switch_forest_brdlfs_selector, climate == CLIMATE_ARCTIC) {
-	1: return sprlay_forest_snowy_brdlfs_growing;
-	0: return sprlay_forest_temp_brdlfs_growing;
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_tile3_selector, climate == CLIMATE_ARCTIC) {
+	1: return sprlay_forest_snowy_tile3;
+	0: return sprlay_forest_temp_tile3;
 }
 	
-switch (FEAT_INDUSTRYTILES, SELF, switch_forest_mixed_selector, climate == CLIMATE_ARCTIC) {
-	1: return sprlay_forest_snowy_mixed_growing;
-	0: return sprlay_forest_temp_mixed_growing;
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_tile4_selector, climate == CLIMATE_ARCTIC) {
+	1: return sprlay_forest_snowy_tile4;
+	0: return sprlay_forest_temp_tile4;
 }	
 
-item (FEAT_INDUSTRYTILES, ind_tile_forest_mixed) {
+item (FEAT_INDUSTRYTILES, ind_tile_forest_tile1) {
     property {
         substitute: 16;
         override: 16;
         accepted_cargos: [[PASS, 8]];
     }
 	graphics {
-		default: switch_forest_mixed_selector;
+		default: switch_forest_tile1_selector;
 	}
 }
 
-item (FEAT_INDUSTRYTILES, ind_tile_forest_pine1) {
+item (FEAT_INDUSTRYTILES, ind_tile_forest_tile2) {
     property {
         substitute: 16;
         override: 16;
         accepted_cargos: [[PASS, 8]];
     }
 	graphics {
-		default: switch_forest_pine1_selector;
+		default: switch_forest_tile2_selector;
 	}
 }
 
-item (FEAT_INDUSTRYTILES, ind_tile_forest_pine2) {
+item (FEAT_INDUSTRYTILES, ind_tile_forest_tile3) {
     property {
         substitute: 16;
         override: 16;
         accepted_cargos: [[PASS, 8]];
     }
 	graphics {
-		default: switch_forest_pine2_selector;
+		default: switch_forest_tile3_selector;
 	}
 }
 
-item (FEAT_INDUSTRYTILES, ind_tile_forest_brdlfs) {
+item (FEAT_INDUSTRYTILES, ind_tile_forest_tile4) {
     property {
         substitute: 16;
         override: 16;
         accepted_cargos: [[PASS, 8]];
     }
 	graphics {
-		default: switch_forest_brdlfs_selector;
+		default: switch_forest_tile4_selector;
 	}
 }
 
@@ -387,57 +393,57 @@ item (FEAT_INDUSTRYTILES, ind_tile_forest_logginghouse) {
 }
 
 tilelayout industry_layout_forest_layout_1 {
-	0, 0: ind_tile_forest_mixed;
-	1, 0: ind_tile_forest_mixed;
-	2, 0: ind_tile_forest_pine1;
-	3, 0: ind_tile_forest_mixed;
+	0, 0: ind_tile_forest_tile4;
+	1, 0: ind_tile_forest_tile4;
+	2, 0: ind_tile_forest_tile1;
+	3, 0: ind_tile_forest_tile4;
 	
-	0, 1: ind_tile_forest_pine2;
-	1, 1: ind_tile_forest_mixed;
-	2, 1: ind_tile_forest_brdlfs;
-	3, 1: ind_tile_forest_pine1;
+	0, 1: ind_tile_forest_tile2;
+	1, 1: ind_tile_forest_tile4;
+	2, 1: ind_tile_forest_tile3;
+	3, 1: ind_tile_forest_tile1;
 	
-	0, 2: ind_tile_forest_mixed;
-	1, 2: ind_tile_forest_pine1;
-	2, 2: ind_tile_forest_brdlfs;
-	3, 2: ind_tile_forest_mixed;
+	0, 2: ind_tile_forest_tile4;
+	1, 2: ind_tile_forest_tile1;
+	2, 2: ind_tile_forest_tile3;
+	3, 2: ind_tile_forest_tile4;
 	
-	0, 3: ind_tile_forest_pine2;
-	1, 3: ind_tile_forest_mixed;
-	2, 3: ind_tile_forest_pine1;
-	3, 3: ind_tile_forest_mixed;
+	0, 3: ind_tile_forest_tile2;
+	1, 3: ind_tile_forest_tile4;
+	2, 3: ind_tile_forest_tile1;
+	3, 3: ind_tile_forest_tile4;
 	
-	0, 4: ind_tile_forest_brdlfs;
-	1, 4: ind_tile_forest_mixed;
+	0, 4: ind_tile_forest_tile3;
+	1, 4: ind_tile_forest_tile4;
 	2, 4: ind_tile_forest_logginghouse;
 	3, 4: ind_tile_forest_brownground;
 }
 
 tilelayout industry_layout_forest_layout_2 {
-	0, 0: ind_tile_forest_mixed;
-	0, 1: ind_tile_forest_mixed;
-	0, 2: ind_tile_forest_pine1;
-	0, 3: ind_tile_forest_mixed;
+	0, 0: ind_tile_forest_tile4;
+	0, 1: ind_tile_forest_tile4;
+	0, 2: ind_tile_forest_tile1;
+	0, 3: ind_tile_forest_tile4;
 	
-	1, 0: ind_tile_forest_pine1;
-	1, 1: ind_tile_forest_mixed;
-	1, 2: ind_tile_forest_brdlfs;
-	1, 3: ind_tile_forest_pine1;
+	1, 0: ind_tile_forest_tile1;
+	1, 1: ind_tile_forest_tile4;
+	1, 2: ind_tile_forest_tile3;
+	1, 3: ind_tile_forest_tile1;
 	
-	2, 0: ind_tile_forest_mixed;
-	2, 1: ind_tile_forest_pine2;
-	2, 2: ind_tile_forest_brdlfs;
-	2, 3: ind_tile_forest_mixed;
+	2, 0: ind_tile_forest_tile4;
+	2, 1: ind_tile_forest_tile2;
+	2, 2: ind_tile_forest_tile3;
+	2, 3: ind_tile_forest_tile4;
 	
-	3, 0: ind_tile_forest_pine1;
-	3, 1: ind_tile_forest_mixed;
-	3, 2: ind_tile_forest_pine2;
-	3, 3: ind_tile_forest_mixed;
+	3, 0: ind_tile_forest_tile1;
+	3, 1: ind_tile_forest_tile4;
+	3, 2: ind_tile_forest_tile2;
+	3, 3: ind_tile_forest_tile4;
 	
 	4, 0: ind_tile_forest_brownground;
 	4, 1: ind_tile_forest_logginghouse;
-	4, 2: ind_tile_forest_mixed;
-	4, 3: ind_tile_forest_brdlfs;
+	4, 2: ind_tile_forest_tile4;
+	4, 3: ind_tile_forest_tile3;
 }
 
 produce (produce_forest,

--- a/src/forest.nml
+++ b/src/forest.nml
@@ -1,37 +1,443 @@
 
 /* *** Begin Forest *** */
 
-spritelayout sprlay_forest_grow_1 {
-	ground		{sprite:GROUNDSPRITE_NORMAL;}
-	building	{sprite:2072;}
+spritelayout sprlay_forest_temp_pine1_growing{
+	ground	{sprite:3943;}
+	//top corner
+	building	{
+	sprite: (construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
+	xoffset: 0;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//bottom corner
+	building {
+	sprite:(construction_state==0 ? 1653 : construction_state==1 ? 1654 : construction_state==2 ? 1655 : 1656);
+	xoffset: 8;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+	// left corner
+	building {
+	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
+	xoffset: 8;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//right corner
+	building {
+	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
+	xoffset: 0;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
 }
 
-spritelayout sprlay_forest_grow_2 {
-	ground		{sprite:GROUNDSPRITE_NORMAL;}
-	building	{sprite:2073;}
+spritelayout sprlay_forest_temp_pine2_growing{
+	ground	{sprite:3943;}
+	//top corner
+	building	{
+	sprite: (construction_state==0 ? 1611 : construction_state==1 ? 1612 : construction_state==2 ? 1613 : 1614);
+	xoffset: 0;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//bottom corner
+	building {
+	sprite: (construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
+	xoffset: 8;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+	// left corner
+	building {
+	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
+	xoffset: 8;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//right corner
+	building {
+	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
+	xoffset: 0;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
 }
 
-spritelayout sprlay_forest_grow_3 {
-	ground		{sprite:GROUNDSPRITE_NORMAL;}
-	building	{sprite:2074;}
+spritelayout sprlay_forest_temp_brdlfs_growing{
+	ground		{sprite: 3943;} 
+	// top corner
+	building	{
+	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
+	xoffset: 0;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//bottom corner
+	building {
+	sprite:(construction_state==0 ? 1611 : construction_state==1 ? 1612 : construction_state==2 ? 1613 : 1614);
+	xoffset: 8;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+	// left corner
+	building {
+	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
+	xoffset: 8;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//right corner
+	building {
+	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
+	xoffset: 0;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+
 }
 
-spritelayout sprlay_forest_grown {
-	ground		{sprite:GROUNDSPRITE_NORMAL;}
-	building	{sprite:2075;}
+spritelayout sprlay_forest_temp_mixed_growing{
+	ground		{sprite: 3943;}
+	// top corner
+	building	{
+	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
+	xoffset: 0;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//bottom corner
+	building {
+	sprite:(construction_state==0 ? 1590 : construction_state==1 ? 1591 : construction_state==2 ? 1592 : 1593);
+	xoffset: 8;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+	// left corner
+	building {
+	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
+	xoffset: 8;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//right corner
+	building {
+	sprite:(construction_state==0 ? 1660 : construction_state==1 ? 1661 : construction_state==2 ? 1662 : 1663);
+	xoffset: 0;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
 }
 
-spritelayout sprlay_forest_cut {
-	ground		{sprite:GROUNDSPRITE_NORMAL;}
-	building	{sprite:2076;}
+spritelayout sprlay_forest_brownground{
+		ground		{sprite: 2022;} 
+	}
+	
+spritelayout sprlay_forest_logginghouse{
+		ground		{sprite: 2022;} 
+		building	{sprite: 2063;}
+	}	
+
+spritelayout sprlay_forest_snowy_pine1_growing{
+	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
+	//top corner 1765
+	building	{
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
+	xoffset: 0;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//bottom corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1800 : construction_state==1 ? 1801 : construction_state==2 ? 1802 : 1803) : (construction_state==0 ? 1744 : construction_state==1 ? 1745 : construction_state==2 ? 1746 : 1747));
+	xoffset: 8;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+	// left corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
+	xoffset: 8;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//right corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
+	xoffset: 0;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
 }
 
-item (FEAT_INDUSTRYTILES, ind_tile_forest_10h) {
+spritelayout sprlay_forest_snowy_pine2_growing{
+	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
+	//top corner 
+	building	{
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1786 : construction_state==1 ? 1787 : construction_state==2 ? 1788 : 1789) : (construction_state==0 ? 1730 : construction_state==1 ? 1731 : construction_state==2 ? 1732 : 1733));
+	xoffset: 0;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//bottom corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
+	xoffset: 8;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+	// left corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
+	xoffset: 8;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//right corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
+	xoffset: 0;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+}
+
+spritelayout sprlay_forest_snowy_brdlfs_growing{
+	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
+	//top corner 
+	building	{
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
+	xoffset: 0;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//bottom corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1786 : construction_state==1 ? 1787 : construction_state==2 ? 1788 : 1789) : (construction_state==0 ? 1730 : construction_state==1 ? 1731 : construction_state==2 ? 1732 : 1733));
+	xoffset: 8;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+	// left corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
+	xoffset: 8;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//right corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
+	xoffset: 0;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+}
+
+spritelayout sprlay_forest_snowy_mixed_growing{
+	ground	{sprite: (terrain_type == TILETYPE_SNOW ? 4531 : 3962);}
+	//top corner 
+	building	{
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
+	xoffset: 0;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//bottom corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1772 : construction_state==1 ? 1773 : construction_state==2 ? 1774 : 1775) : (construction_state==0 ? 1716 : construction_state==1 ? 1717 : construction_state==2 ? 1718 : 1719));
+	xoffset: 8;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+	// left corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
+	xoffset: 8;
+	yoffset: 0;
+	xextent: 8;
+	yextent: 8;
+	}
+	//right corner
+	building {
+	sprite: (terrain_type == TILETYPE_SNOW ? (construction_state==0 ? 1765 : construction_state==1 ? 1766 : construction_state==2 ? 1767 : 1768) : (construction_state==0 ? 1709 : construction_state==1 ? 1710 : construction_state==2 ? 1711 : 1712));
+	xoffset: 0;
+	yoffset: 8;
+	xextent: 8;
+	yextent: 8;
+	}
+}
+
+/* TEMPERATE and ARCTIC graphics switches */
+
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_pine1_selector, climate == CLIMATE_ARCTIC){
+	1: return sprlay_forest_snowy_pine1_growing;
+	0: return sprlay_forest_temp_pine1_growing;
+	}
+	
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_pine2_selector, climate == CLIMATE_ARCTIC){
+	1: return sprlay_forest_snowy_pine2_growing;
+	0: return sprlay_forest_temp_pine2_growing;
+	}
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_brdlfs_selector, climate == CLIMATE_ARCTIC){
+	1: return sprlay_forest_snowy_brdlfs_growing;
+	0: return sprlay_forest_temp_brdlfs_growing;
+	}
+	
+switch (FEAT_INDUSTRYTILES, SELF, switch_forest_mixed_selector, climate == CLIMATE_ARCTIC){
+	1: return sprlay_forest_snowy_mixed_growing;
+	0: return sprlay_forest_temp_mixed_growing;
+	}	
+
+item (FEAT_INDUSTRYTILES, ind_tile_forest_mixed) {
     property {
         substitute: 16;
-        override: 16;
+        //override: 16;
         accepted_cargos: [[PASS, 8]];
     }
+	graphics{
+		default: switch_forest_mixed_selector;
+	}
+}
+
+item (FEAT_INDUSTRYTILES, ind_tile_forest_pine1) {
+    property {
+        substitute: 16;
+        //override: 16;
+        accepted_cargos: [[PASS, 8]];
+    }
+	graphics{
+		default: switch_forest_pine1_selector;
+	}
+}
+
+item (FEAT_INDUSTRYTILES, ind_tile_forest_pine2) {
+    property {
+        substitute: 16;
+        //override: 16;
+        accepted_cargos: [[PASS, 8]];
+    }
+	graphics{
+		default: switch_forest_pine2_selector;
+	}
+}
+
+item (FEAT_INDUSTRYTILES, ind_tile_forest_brdlfs) {
+    property {
+        substitute: 16;
+        //override: 16;
+        accepted_cargos: [[PASS, 8]];
+    }
+	graphics{
+		default: switch_forest_brdlfs_selector;
+	}
+}
+
+item (FEAT_INDUSTRYTILES, ind_tile_forest_brownground) {
+    property {
+        substitute: 16;
+        //override: 16;
+        accepted_cargos: [[PASS, 8]];
+    }
+	graphics{
+		default: sprlay_forest_brownground;
+	}
+}
+
+item (FEAT_INDUSTRYTILES, ind_tile_forest_logginghouse) {
+    property {
+        substitute: 16;
+        //override: 16;
+        accepted_cargos: [[PASS, 8]];
+    }
+	graphics{
+		default: sprlay_forest_logginghouse;
+	}
+}
+
+tilelayout industry_layout_forest_layout_1 {
+	0, 0: ind_tile_forest_mixed;
+	1, 0: ind_tile_forest_mixed;
+	2, 0: ind_tile_forest_pine1;
+	3, 0: ind_tile_forest_mixed;
+	
+	0, 1: ind_tile_forest_pine2;
+	1, 1: ind_tile_forest_mixed;
+	2, 1: ind_tile_forest_brdlfs;
+	3, 1: ind_tile_forest_pine1;
+	
+	0, 2: ind_tile_forest_mixed;
+	1, 2: ind_tile_forest_pine1;
+	2, 2: ind_tile_forest_brdlfs;
+	3, 2: ind_tile_forest_mixed;
+	
+	0, 3: ind_tile_forest_pine2;
+	1, 3: ind_tile_forest_mixed;
+	2, 3: ind_tile_forest_pine1;
+	3, 3: ind_tile_forest_mixed;
+	
+	0, 4: ind_tile_forest_brdlfs;
+	1, 4: ind_tile_forest_mixed;
+	2, 4: ind_tile_forest_logginghouse;
+	3, 4: ind_tile_forest_brownground;
+}
+
+tilelayout industry_layout_forest_layout_2 {
+	0, 0: ind_tile_forest_mixed;
+	0, 1: ind_tile_forest_mixed;
+	0, 2: ind_tile_forest_pine1;
+	0, 3: ind_tile_forest_mixed;
+	
+	1, 0: ind_tile_forest_pine1;
+	1, 1: ind_tile_forest_mixed;
+	1, 2: ind_tile_forest_brdlfs;
+	1, 3: ind_tile_forest_pine1;
+	
+	2, 0: ind_tile_forest_mixed;
+	2, 1: ind_tile_forest_pine2;
+	2, 2: ind_tile_forest_brdlfs;
+	2, 3: ind_tile_forest_mixed;
+	
+	3, 0: ind_tile_forest_pine1;
+	3, 1: ind_tile_forest_mixed;
+	3, 2: ind_tile_forest_pine2;
+	3, 3: ind_tile_forest_mixed;
+	
+	4, 0: ind_tile_forest_brownground;
+	4, 1: ind_tile_forest_logginghouse;
+	4, 2: ind_tile_forest_mixed;
+	4, 3: ind_tile_forest_brdlfs;
 }
 
 produce (produce_forest,
@@ -52,6 +458,7 @@ switch (FEAT_INDUSTRIES, SELF, loc_check_forest, IsTown() && (IsInQuadrantNE() |
 item (FEAT_INDUSTRIES, industry_forest, 3) {
 	property {
 		substitute: INDUSTRYTYPE_FOREST;
+		layouts: [industry_layout_forest_layout_1, industry_layout_forest_layout_2,];
 		life_type: IND_LIFE_TYPE_ORGANIC;
 		cargo_types: [
             produce_cargo("WOOD", 0),
@@ -63,109 +470,17 @@ item (FEAT_INDUSTRIES, industry_forest, 3) {
         prob_map_gen: 2; // Account for difficulty of finding suitable locatiom
         prob_in_game: 0;
 		fund_cost_multiplier: 255;
+		
 	}
 	graphics {
 		extra_text_industry: StringGetPrimaryHelptext();
         location_check: loc_check_forest;
-        produce_256_ticks: switch_produce_forest;
+        produce_256_ticks: switch_produce_forest;			
         /* Don't allow any production changes */
 		build_prod_change: 16; // 100% production
 		monthly_prod_change: CB_RESULT_IND_PROD_NO_CHANGE;
 		random_prod_change: CB_RESULT_IND_PROD_NO_CHANGE;
 	}
 }
-
-/* Forest objects */
-
-item (FEAT_OBJECTS, object_item_forest_grow_1) {
-	property {
-		class:					"HSIN";
-		classname:				string(STR_NAME_OBJECT_MENU);
-		name:					TTD_STR_INDUSTRY_NAME_FOREST;
-		climates_available:		ALL_CLIMATES;
-		object_flags:			bitmask(OBJ_FLAG_ANYTHING_REMOVE);
-		build_cost_multiplier:	0;
-		remove_cost_multiplier:	0;
-		size:					[1,1];
-		introduction_date:		1700;
-		num_views:				1;
-	}
-	graphics {
-		default:				sprlay_forest_grow_1;
-	}
-}
-
-item (FEAT_OBJECTS, object_item_forest_grow_2) {
-	property {
-		class:					"HSIN";
-		classname:				string(STR_NAME_OBJECT_MENU);
-		name:					TTD_STR_INDUSTRY_NAME_FOREST;
-		climates_available:		ALL_CLIMATES;
-		object_flags:			bitmask(OBJ_FLAG_ANYTHING_REMOVE);
-		build_cost_multiplier:	0;
-		remove_cost_multiplier:	0;
-		size:					[1,1];
-		introduction_date:		1700;
-		num_views:				1;
-	}
-	graphics {
-		default:				sprlay_forest_grow_2;
-	}
-}
-
-item (FEAT_OBJECTS, object_item_forest_grow_3) {
-	property {
-		class:					"HSIN";
-		classname:				string(STR_NAME_OBJECT_MENU);
-		name:					TTD_STR_INDUSTRY_NAME_FOREST;
-		climates_available:		ALL_CLIMATES;
-		object_flags:			bitmask(OBJ_FLAG_ANYTHING_REMOVE);
-		build_cost_multiplier:	0;
-		remove_cost_multiplier:	0;
-		size:					[1,1];
-		introduction_date:		1700;
-		num_views:				1;
-	}
-	graphics {
-		default:				sprlay_forest_grow_3;
-	}
-}
-
-item (FEAT_OBJECTS, object_item_forest_grown) {
-	property {
-		class:					"HSIN";
-		classname:				string(STR_NAME_OBJECT_MENU);
-		name:					TTD_STR_INDUSTRY_NAME_FOREST;
-		climates_available:		ALL_CLIMATES;
-		object_flags:			bitmask(OBJ_FLAG_ANYTHING_REMOVE);
-		build_cost_multiplier:	0;
-		remove_cost_multiplier:	0;
-		size:					[1,1];
-		introduction_date:		1700;
-		num_views:				1;
-	}
-	graphics {
-		default:				sprlay_forest_grown;
-	}
-}
-
-item (FEAT_OBJECTS, object_item_forest_cut) {
-	property {
-		class:					"HSIN";
-		classname:				string(STR_NAME_OBJECT_MENU);
-		name:					TTD_STR_INDUSTRY_NAME_FOREST;
-		climates_available:		ALL_CLIMATES;
-		object_flags:			bitmask(OBJ_FLAG_ANYTHING_REMOVE);
-		build_cost_multiplier:	0;
-		remove_cost_multiplier:	0;
-		size:					[1,1];
-		introduction_date:		1700;
-		num_views:				1;
-	}
-	graphics {
-		default:				sprlay_forest_cut;
-	}
-}
-
 
 /* *** End Forest *** */

--- a/src/forest.nml
+++ b/src/forest.nml
@@ -302,7 +302,17 @@ spritelayout sprlay_forest_brownground {
 spritelayout sprlay_forest_logginghouse {
 		ground		{sprite: 2022;} 
 		building	{sprite: 2063;}
-	}	
+	}
+
+spritelayout sprlay_forest_brownlogs {
+		ground		{sprite: 2022;} 
+		building	{sprite: 2071;}
+	}
+	
+spritelayout sprlay_forest_blacklogs {
+		ground		{sprite: 2022;} 
+		building	{sprite: 2070;}
+	}
 
 /* TEMPERATE and ARCTIC graphics switches */
 
@@ -392,6 +402,28 @@ item (FEAT_INDUSTRYTILES, ind_tile_forest_logginghouse) {
 	}
 }
 
+item (FEAT_INDUSTRYTILES, ind_tile_forest_brownlogs) {
+    property {
+        substitute: 16;
+        override: 16;
+        accepted_cargos: [[PASS, 8]];
+    }
+	graphics {
+		default: sprlay_forest_brownlogs;
+	}
+}
+
+item (FEAT_INDUSTRYTILES, ind_tile_forest_blacklogs) {
+    property {
+        substitute: 16;
+        override: 16;
+        accepted_cargos: [[PASS, 8]];
+    }
+	graphics {
+		default: sprlay_forest_blacklogs;
+	}
+}
+
 tilelayout industry_layout_forest_layout_1 {
 	0, 0: ind_tile_forest_tile4;
 	1, 0: ind_tile_forest_tile4;
@@ -417,33 +449,41 @@ tilelayout industry_layout_forest_layout_1 {
 	1, 4: ind_tile_forest_tile4;
 	2, 4: ind_tile_forest_logginghouse;
 	3, 4: ind_tile_forest_brownground;
+	
+	4, 4: ind_tile_forest_brownground;
+	4, 3: ind_tile_forest_brownlogs;
+	4, 2: ind_tile_forest_blacklogs;	
 }
 
 tilelayout industry_layout_forest_layout_2 {
-	0, 0: ind_tile_forest_tile4;
 	0, 1: ind_tile_forest_tile4;
-	0, 2: ind_tile_forest_tile1;
-	0, 3: ind_tile_forest_tile4;
+	0, 2: ind_tile_forest_tile4;
+	0, 3: ind_tile_forest_tile1;
+	0, 4: ind_tile_forest_tile4;
 	
-	1, 0: ind_tile_forest_tile1;
-	1, 1: ind_tile_forest_tile4;
-	1, 2: ind_tile_forest_tile3;
-	1, 3: ind_tile_forest_tile1;
+	1, 1: ind_tile_forest_tile1;
+	1, 2: ind_tile_forest_tile4;
+	1, 3: ind_tile_forest_tile3;
+	1, 4: ind_tile_forest_tile1;
 	
-	2, 0: ind_tile_forest_tile4;
-	2, 1: ind_tile_forest_tile2;
-	2, 2: ind_tile_forest_tile3;
-	2, 3: ind_tile_forest_tile4;
+	2, 1: ind_tile_forest_tile4;
+	2, 2: ind_tile_forest_tile2;
+	2, 3: ind_tile_forest_tile3;
+	2, 4: ind_tile_forest_tile4;
 	
-	3, 0: ind_tile_forest_tile1;
-	3, 1: ind_tile_forest_tile4;
-	3, 2: ind_tile_forest_tile2;
-	3, 3: ind_tile_forest_tile4;
+	3, 1: ind_tile_forest_tile1;
+	3, 2: ind_tile_forest_tile4;
+	3, 3: ind_tile_forest_tile2;
+	3, 4: ind_tile_forest_tile4;
+	
+	4, 1: ind_tile_forest_brownground;
+	4, 2: ind_tile_forest_logginghouse;
+	4, 3: ind_tile_forest_tile4;
+	4, 4: ind_tile_forest_tile3;
 	
 	4, 0: ind_tile_forest_brownground;
-	4, 1: ind_tile_forest_logginghouse;
-	4, 2: ind_tile_forest_tile4;
-	4, 3: ind_tile_forest_tile3;
+	3, 0: ind_tile_forest_brownlogs;
+	2, 0: ind_tile_forest_blacklogs;	
 }
 
 produce (produce_forest,


### PR DESCRIPTION
Forest now has 2 layouts, which mirror each other in terms of rotation. Graphics are now snow-aware and climate-aware.

Temperate forest
![image](https://github.com/2TallTyler/improved_town_industries/assets/90719319/4a91f6c3-8740-4d13-9bd3-7def57ca6aeb)
Arctic forest
![image](https://github.com/2TallTyler/improved_town_industries/assets/90719319/16a2cdec-590d-470d-9f55-fc61d94417a7)
Arctic forest no snow
![image](https://github.com/2TallTyler/improved_town_industries/assets/90719319/213bb470-b87d-49c5-96d1-845ee84242ca)

Snow graphics is dynamic, so if player uses GRF that moves snow line, such as "OpenGFX+ Landscape" - trees and ground will turn to their snowy variant.

I have removed the forest objects from Landscaping menu as they are redundant with using basic trees. And I have removed the "ind_tile_forest_10h" object which served no obvious function and was not referenced anywhere in the whole GRF - I checked with fully combined NML file.