### PR TITLE
Change: allow using the quadrant param in the scenario editor

### DIFF
--- a/src/functions.nml
+++ b/src/functions.nml
@@ -177,7 +177,7 @@ switch (FEAT_INDUSTRIES, SELF, GetTileY, var[0x80, 0, 0xFFFFFFFF] / map_x_edge) 
 
  /**
  * Check if an industry is in the North quadrant of the map.
- * @return 1 if this is true, we're in Scenario Editor, or param_primary_quadrants disables this feature, else 0.
+ * @return 1 if this is true, or param_primary_quadrants disables this feature, else 0.
  */
 switch (FEAT_INDUSTRIES, SELF, IsInQuadrantN,
 	!param_primary_quadrants || (GetTileX() < (map_x_edge / 2) && GetTileY() < (map_y_edge / 2))
@@ -187,7 +187,7 @@ switch (FEAT_INDUSTRIES, SELF, IsInQuadrantN,
  * This function is UNUSED but kept for reference for other NewGRF authors!
  *
  * Check if an industry is in the East quadrant of the map.
- * @return 1 if this is true, we're in Scenario Editor, or param_primary_quadrants disables this feature, else 0.
+ * @return 1 if this is true, or param_primary_quadrants disables this feature, else 0.
  */
 
 /*
@@ -198,7 +198,7 @@ switch (FEAT_INDUSTRIES, SELF, IsInQuadrantE,
 
 /**
  * Check if an industry is in the South quadrant of the map.
- * @return 1 if this is true, we're in Scenario Editor, or param_primary_quadrants disables this feature, else 0.
+ * @return 1 if this is true, or param_primary_quadrants disables this feature, else 0.
  */
 switch (FEAT_INDUSTRIES, SELF, IsInQuadrantS,
 	!param_primary_quadrants || (GetTileX() > (map_x_edge / 2) && GetTileY() > (map_y_edge / 2))
@@ -206,7 +206,7 @@ switch (FEAT_INDUSTRIES, SELF, IsInQuadrantS,
 
 /**
  * Check if an industry is in the West quadrant of the map.
- * @return 1 if this is true, we're in Scenario Editor, or param_primary_quadrants disables this feature, else 0.
+ * @return 1 if this is true, or param_primary_quadrants disables this feature, else 0.
  */
 switch (FEAT_INDUSTRIES, SELF, IsInQuadrantW,
 	!param_primary_quadrants || (GetTileX() > (map_x_edge / 2) && GetTileY() < (map_y_edge / 2))
@@ -214,7 +214,7 @@ switch (FEAT_INDUSTRIES, SELF, IsInQuadrantW,
 
 /**
  * Check if an industry is in the Northeast quadrant of the map.
- * @return 1 if this is true, we're in Scenario Editor, or param_primary_quadrants disables this feature, else 0. 
+ * @return 1 if this is true, or param_primary_quadrants disables this feature, else 0. 
  */
 switch (FEAT_INDUSTRIES, SELF, IsInQuadrantNE,
     !param_primary_quadrants || ((GetTileX() * map_y_edge) < (GetTileY() * map_x_edge)) && ((GetTileX() * map_y_edge + GetTileY() * map_x_edge) < (map_x_edge * map_y_edge))
@@ -222,7 +222,7 @@ switch (FEAT_INDUSTRIES, SELF, IsInQuadrantNE,
 
 /**
  * Check if an industry is in the Southeast quadrant of the map.
- * @return 1 if this is true, we're in Scenario Editor, or param_primary_quadrants disables this feature, else 0. 
+ * @return 1 if this is true, or param_primary_quadrants disables this feature, else 0. 
  */
 switch (FEAT_INDUSTRIES, SELF, IsInQuadrantSE,
     !param_primary_quadrants || ((GetTileX() * map_y_edge) < (GetTileY() * map_x_edge)) && ((GetTileX() * map_y_edge + GetTileY() * map_x_edge) > (map_x_edge * map_y_edge))
@@ -230,7 +230,7 @@ switch (FEAT_INDUSTRIES, SELF, IsInQuadrantSE,
 
 /**
  * Check if an industry is in the Southwest quadrant of the map.
- * @return 1 if this is true, we're in Scenario Editor, or param_primary_quadrants disables this feature, else 0. 
+ * @return 1 if this is true, or param_primary_quadrants disables this feature, else 0. 
  */
 switch (FEAT_INDUSTRIES, SELF, IsInQuadrantSW,
     !param_primary_quadrants || ((GetTileX() * map_y_edge) > (GetTileY() * map_x_edge)) && ((GetTileX() * map_y_edge + GetTileY() * map_x_edge) > (map_x_edge * map_y_edge))
@@ -238,7 +238,7 @@ switch (FEAT_INDUSTRIES, SELF, IsInQuadrantSW,
 
 /**
  * Check if an industry is in the Northwest quadrant of the map.
- * @return 1 if this is true, we're in Scenario Editor, or param_primary_quadrants disables this feature, else 0. 
+ * @return 1 if this is true, or param_primary_quadrants disables this feature, else 0. 
  */
 switch (FEAT_INDUSTRIES, SELF, IsInQuadrantNW,
     !param_primary_quadrants || ((GetTileX() * map_y_edge) > (GetTileY() * map_x_edge)) && ((GetTileX() * map_y_edge + GetTileY() * map_x_edge) < (map_x_edge * map_y_edge))


### PR DESCRIPTION
This allows the use of the "Primary industry region" parameter in the scenario editor.