### PR TITLE
Fix: Non-passenger production of oil refinery and recycling centre at low town population levels

### DIFF
--- a/src/functions.nml
+++ b/src/functions.nml
@@ -90,6 +90,17 @@ switch (FEAT_INDUSTRIES, PARENT, GetAdjustedProductionEfficiency, percent_transp
  */
 switch (FEAT_INDUSTRIES, SELF, GetSecondaryProductionLevel, (TownPopulation() / 5 / 8 * GetAdjustedProductionEfficiency()) / 100) {return;}
 
+/**
+ * Store 1/3 of the input production level in temporary storage register 5, with accumulation
+ * of the remainder in permanent storage register 0.
+ * @param prod_level The secondary production level.
+ */
+switch (FEAT_INDUSTRIES, SELF, ProcessOneThirdSecondaryProduction, prod_level, [
+    STORE_TEMP(prod_level + LOAD_PERM(0), 5),
+    STORE_PERM(LOAD_TEMP(5) % 3, 0),
+    STORE_TEMP(LOAD_TEMP(5) / 3, 5),
+]) {return;}
+
 /** 
  * Get the primary industry population multiplier based on the population of the town. 
  * @return The multiplier, in range 1-5.

--- a/src/oil_refinery.nml
+++ b/src/oil_refinery.nml
@@ -184,25 +184,18 @@ tilelayout industry_layout_oil_refinery_3 {
 }
 
 produce (produce_oil_refinery,
-    [OIL_: LOAD_TEMP(1);],                                                     // consume
-    [RFPR: LOAD_TEMP(1) / 3; PLAS: LOAD_TEMP(1) * 2 / 3; PASS: LOAD_TEMP(2);], // produce
-    0                                                                          // don't run callback again
+    [OIL_: LOAD_TEMP(1);],                                             // consume
+    [RFPR: LOAD_TEMP(5); PLAS: LOAD_TEMP(5) * 2; PASS: LOAD_TEMP(2);], // produce
+    0                                                                  // don't run callback again
 )
-
-/* If we don't have enough stored, produce as much as we can anyway. */
-switch (FEAT_INDUSTRIES, SELF, switch_produce_oil_refinery_min, [
-    STORE_TEMP(incoming_cargo_waiting("OIL_"), 1), // Set the production amount to the current input stockpile
-    STORE_TEMP((((LOAD_TEMP(1) / 4) * transported_last_month_pct("RFPR")) / 100), 2), // Set the passenger production level
-    ]) {produce_oil_refinery;}
 
 /* Determine the production level and see if we have enough stored to meet it. */
 switch (FEAT_INDUSTRIES, SELF, switch_produce_oil_refinery_2, [
-    STORE_TEMP(GetSecondaryProductionLevel(), 1), // Get production level
+    STORE_TEMP(min(GetSecondaryProductionLevel(), incoming_cargo_waiting("OIL_")), 1), // Get production level
+    ProcessOneThirdSecondaryProduction(LOAD_TEMP(1)),
     STORE_TEMP((((LOAD_TEMP(1) / 4) * transported_last_month_pct("RFPR")) / 100), 2), // Set the passenger production level
-    incoming_cargo_waiting("OIL_") > LOAD_TEMP(1), // Check if there's enough OIL_ for this production level
     ]) {
-        1: produce_oil_refinery;
-        switch_produce_oil_refinery_min;
+        produce_oil_refinery;
     }
 
 /* If no cargo is waiting, bail out. */

--- a/src/recycling_center.nml
+++ b/src/recycling_center.nml
@@ -104,25 +104,18 @@ tilelayout industry_layout_recycling_center_1 {
 }
 
 produce (produce_recycling_center,
-    [WSTE: LOAD_TEMP(1);],                                                                        // consume
-    [SCMT: LOAD_TEMP(1) / 3; PLAS: LOAD_TEMP(1) / 3; SCPR: LOAD_TEMP(1) /3; PASS: LOAD_TEMP(2);], // produce
-    0                                                                                             // don't run callback again
+    [WSTE: LOAD_TEMP(1);],                                                             // consume
+    [SCMT: LOAD_TEMP(5); PLAS: LOAD_TEMP(5); SCPR: LOAD_TEMP(5); PASS: LOAD_TEMP(2);], // produce
+    0                                                                                  // don't run callback again
 )
-
-/* If we don't have enough stored, produce as much as we can anyway. */
-switch (FEAT_INDUSTRIES, SELF, switch_produce_recycling_center_min, [
-    STORE_TEMP(incoming_cargo_waiting("WSTE"), 1), // Set the production amount to the current input stockpile
-    STORE_TEMP((((LOAD_TEMP(1) / 4) * transported_last_month_pct("SCMT")) / 100), 2), // Set the passenger production level
-    ]) {produce_recycling_center;}
 
 /* Determine the production level and see if we have enough stored to meet it. */
 switch (FEAT_INDUSTRIES, SELF, switch_produce_recycling_center_2, [
-    STORE_TEMP(GetSecondaryProductionLevel(), 1), // Get production level
+    STORE_TEMP(min(GetSecondaryProductionLevel(), incoming_cargo_waiting("WSTE")), 1), // Get production level
+    ProcessOneThirdSecondaryProduction(LOAD_TEMP(1)),
     STORE_TEMP((((LOAD_TEMP(1) / 4) * transported_last_month_pct("SCMT")) / 100), 2), // Set the passenger production level
-    incoming_cargo_waiting("WSTE") > LOAD_TEMP(1), // Check if there's enough Wood for this production level
     ]) {
-        1: produce_recycling_center;
-        switch_produce_recycling_center_min;
+        produce_recycling_center;
     }
 
 /* If no cargo is waiting, bail out. */


### PR DESCRIPTION
Secondary production values < 3 resulted on no production due to (production / 3) rounding to 0.
Accumulate remainder in permanent storage.
Remove redundant code to facilitate the above change.

Doesn't fix similar issues in passenger production.